### PR TITLE
chore: 1.0.10 update

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 1.0.10
+
+-adds NPM keywords to help people actually finds the package
+-renames removeLocationStream to removeLocation. the former name was an artifact of an older version of this package and since it doesn't stream anything anymore, i figured to take it out to avoid confusion.
+-uncomment unused arrayBufferToBase64 helper function. it was commented out because we didn't need it but presumably some client might
+
 # 1.0.9
 
 Add metadata to point npm package back to our github repo.

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ Currently compatible with JPG, PNG, TIF, MOV, MP4
 
 ## Usage
 
-`removeLocationStream` is the main removal function, although some other utility functions
+`removeLocation` is the main removal function, although some other utility functions
 are provided in the index to help read in data correctly if needed. This is how the package
 looks being used in react native with react-native-fs:
 
 ```javascript
-import { removeLocationStream, base64StringToArrayBuffer } from '@xoi/gps-metadata-remover'
+import { removeLocation, base64StringToArrayBuffer } from '@xoi/gps-metadata-remover'
 
 const read = async (size, offset) => {
   const base64Data = await rnfs.read(destPath, size, offset, 'base64')
@@ -26,10 +26,10 @@ const read = async (size, offset) => {
 const write = async (writeValue, entryOffset, encoding) => {
   await rnfs.write(destPath, writeValue, entryOffset, encoding)
 }
-const gpsWasRemoved = await removeLocationStream(destPath, read, write)
+const gpsWasRemoved = await removeLocation(destPath, read, write)
 ```
 
-`removeLocationStream` returns `true` if GPS metadata was found and rewritten and `false`
+`removeLocation` returns `true` if GPS metadata was found and rewritten and `false`
 if no GPS metadata was found and nothing was rewritten.
 
 This package is platform-agnostic, so the client is expected to pass in filesystem

--- a/__tests__/utils/nodeStripContent.js
+++ b/__tests__/utils/nodeStripContent.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const { removeLocationStream } = require('../../lib/index')
+const { removeLocation } = require('../../lib/index')
 const util = require('util') 
 const fs = require('fs')
 const awaitableOpen = util.promisify(fs.open)
@@ -31,7 +31,7 @@ const removeLocationFromFile = async(fileName, sourceDirectory, destDirectory) =
     const buffer = Buffer.alloc(writeValue.length, writeValue, encoding)
     await awaitableWrite(fileDescriptor, buffer, 0, writeValue.length, entryOffset)
   }
-  const locationRemoved = await removeLocationStream(tempFilePath, read, write)
+  const locationRemoved = await removeLocation(tempFilePath, read, write)
   if (locationRemoved) {
   console.log('found GPS, wrote stripped file to ', tempFilePath)
   } else {

--- a/package.json
+++ b/package.json
@@ -49,5 +49,26 @@
     "test-multiple": "for i in {1..10}; do jest --runInBand --silent || (echo 'Failed after $i attempts' && break); done",
     "remove-metadata-batch": "node scripts/batchRemoveMetadata.js",
     "test:jenkins": "echo 'No Tests Implemented'"
-  }
+  },
+  "keywords": [
+    "exif",
+    "gps",
+    "metadata",
+    "jpeg",
+    "jpg",
+    "mp4",
+    "mov",
+    "png",
+    "tiff",
+    "erase",
+    "delete",
+    "remove",
+    "js",
+    "images",
+    "privacy",
+    "web",
+    "mobile",
+    "geolocation",
+    "location"
+  ]
 }

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ export const removeLocation = async (photoUri: string, read: ReadFunction, write
     : await imageGpsExifRemoverSkip(read, write)
 }
 
-/* export const arrayBufferToBase64 = (buffer: ArrayBuffer) => {
+export const arrayBufferToBase64 = (buffer: ArrayBuffer) => {
   let binary = ''
   const bytes = new Uint8Array(buffer)
   const len = bytes.byteLength
@@ -25,7 +25,7 @@ export const removeLocation = async (photoUri: string, read: ReadFunction, write
     binary += String.fromCharCode(bytes[i])
   }
   return base64.btoa(binary)
-} */
+}
 
 export const base64StringToArrayBuffer = async (base64String: string): Promise<Buffer> => {
   const binaryString = await base64.atob(base64String)

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ function removeFileSlashPrefix(path: string): string {
   return path.replace(/^(file:\/\/)/, '')
 }
 
-export const removeLocationStream = async (photoUri: string, read: ReadFunction, write: WriteFunction): Promise<boolean> => {
+export const removeLocation = async (photoUri: string, read: ReadFunction, write: WriteFunction): Promise<boolean> => {
   const preparedUri = removeFileSlashPrefix(photoUri)
   return isVideo(preparedUri)
     ? await videoGpsMetadataRemoverSkip(read, write)


### PR DESCRIPTION
-adds NPM keywords to help people actually finds the package
-renames `removeLocationStream` to `removeLocation`. the former name was an artifact of an older version of this package and since it doesn't stream anything anymore, i figured to take it out to avoid confusion.
-uncomment unused `arrayBufferToBase64` helper function. it was commented out because we didn't need it but presumably some client might