### PR TITLE
feat: remove logs

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -11,6 +11,7 @@
     }],
     ["@babel/plugin-proposal-class-properties", {
       loose: true
-    }]
+    }],
+    ["babel-plugin-transform-remove-console"]
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ lib/
 **/.DS_Store
 __tests__/images/**/processed
 yarn-error.log*
+.idea/

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@babel/plugin-transform-modules-commonjs": "^7.11.0",
     "@babel/preset-env": "^7.11.0",
     "@babel/preset-flow": "^7.11.0",
+    "babel-plugin-transform-remove-console": "^6.9.4",
     "flow-bin": "^0.109.0",
     "flow-copy-source": "^2.0.9",
     "gm": "^1.23.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1554,6 +1554,11 @@ babel-plugin-polyfill-regenerator@^0.1.2:
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.1.4"
 
+babel-plugin-transform-remove-console@^6.9.4:
+  version "6.9.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz#b980360c067384e24b357a588d807d3c83527780"
+  integrity sha1-uYA2DAZzhOJLNXpYjYB9PINSd4A=
+
 babel-preset-current-node-syntax@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz#b4399239b89b2a011f9ddbe3e4f401fc40cff73b"


### PR DESCRIPTION
Would love to use this in a production app, but it really jams the logs in our prod node environment. Unless there's a good reason to use something like the `debug` log package, I'd propose just cleaning the logs out of the build