### PR TITLE
feat: Make xmp removal optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ One of the metadata formats from which this package removes metadata is Adobe's 
 
 Currently, if it finds XMP metadata in a file, this package simply wipes the whole of the XMP block rather than just the GPS; this code was originally written under a bit of a time crunch and removing all of the XMP was acceptable since we don't use XMP at all.
 
-If you need to leave XMP intact, pass `true` to the optional `skipXMPRemoval` argument in `removeLocation`:
+If you need to leave XMP intact, pass the optional `options` parameter object to `removeLocation` with `skipXMPRemoval` set to `true`:
 
 ```javascript
-const gpsWasRemoved = await removeLocation(destPath, read, write, true)
+const gpsWasRemoved = await removeLocation(destPath, read, write, { skipXMPRemoval })
 ```
 
 At some point I'll write (or accept a PR for) the logic to properly find and remove just the GPS from XMP and leave the rest.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ export type ReadFunction = (size: number, offset: number) => Promise<Buffer>
 export type WriteFunction = (writeValue: string, entryOffset: number, encoding: string) => Promise<void>
 ```
 
-### XMP Removal
+#### XMP Removal
 
 One of the metadata formats from which this package removes metadata is Adobe's [XMP](https://www.adobe.com/products/xmp.html).
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,20 @@ export type ReadFunction = (size: number, offset: number) => Promise<Buffer>
 export type WriteFunction = (writeValue: string, entryOffset: number, encoding: string) => Promise<void>
 ```
 
+### XMP Removal
+
+One of the metadata formats from which this package removes metadata is Adobe's [XMP](https://www.adobe.com/products/xmp.html).
+
+Currently, if it finds XMP metadata in a file, this package simply wipes the whole of the XMP block rather than just the GPS; this code was originally written under a bit of a time crunch and removing all of the XMP was acceptable since we don't use XMP at all.
+
+If you need to leave XMP intact, pass `true` to the optional `skipXMPRemoval` argument in `removeLocation`:
+
+```javascript
+const gpsWasRemoved = await removeLocation(destPath, read, write, true)
+```
+
+At some point I'll write (or accept a PR for) the logic to properly find and remove just the GPS from XMP and leave the rest.
+
 ## Testing
 
 `nodeStripContent.js` is a node utility that takes a file name, source directory, and destination directory,

--- a/src/gpsRemoverHelpers.js
+++ b/src/gpsRemoverHelpers.js
@@ -4,6 +4,9 @@ import base64 from 'Base64'
 
 export type ReadFunction = (size: number, offset: number) => Promise<Buffer>
 export type WriteFunction = (writeValue: string, entryOffset: number, encoding: string) => Promise<void>
+export type Options = {
+  skipXMPRemoval?: boolean
+}
 
 export const readNextChunkIntoDataView
 = async (size: number, offset: number, read: ReadFunction) => {

--- a/src/imageGpsExifRemover.js
+++ b/src/imageGpsExifRemover.js
@@ -102,7 +102,7 @@ const findGPSinExifJpg
 }
 
 export const imageGpsExifRemoverSkip
-= async (read: ReadFunction, write: WriteFunction): Promise<boolean> => {
+= async (read: ReadFunction, write: WriteFunction, skipXMPRemoval: boolean): Promise<boolean> => {
   const fileTypeDataView = await readNextChunkIntoDataView(4, 0, read)
   const fileTypeTag = fileTypeDataView.getUint32(0)
   let offset = 0
@@ -126,7 +126,7 @@ export const imageGpsExifRemoverSkip
         = await readNextChunkIntoDataView(pngCurrentTagSize, offsetOfExifData, read)
         console.log('png exif view', exifDataView)
         removedGps = await findGPSinExifJpg(exifDataView, pngCurrentTagSize, offsetOfExifData, read, write)
-      } else if (pngCurrentTag === PNG_ITXT_TAG) {
+      } else if (pngCurrentTag === PNG_ITXT_TAG && !skipXMPRemoval) {
         console.log('found itxt in png')
         const offsetOfPotentialXMPTag = offset + 8
         if(pngCurrentTagSize >= PNG_XMP_TAG.length) {

--- a/src/index.js
+++ b/src/index.js
@@ -10,11 +10,11 @@ function removeFileSlashPrefix(path: string): string {
   return path.replace(/^(file:\/\/)/, '')
 }
 
-export const removeLocation = async (photoUri: string, read: ReadFunction, write: WriteFunction): Promise<boolean> => {
+export const removeLocation = async (photoUri: string, read: ReadFunction, write: WriteFunction, skipXMPRemoval: boolean = false): Promise<boolean> => {
   const preparedUri = removeFileSlashPrefix(photoUri)
   return isVideo(preparedUri)
-    ? await videoGpsMetadataRemoverSkip(read, write)
-    : await imageGpsExifRemoverSkip(read, write)
+    ? await videoGpsMetadataRemoverSkip(read, write, skipXMPRemoval)
+    : await imageGpsExifRemoverSkip(read, write, skipXMPRemoval)
 }
 
 export const arrayBufferToBase64 = (buffer: ArrayBuffer) => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 // @flow
 import { imageGpsExifRemoverSkip } from './imageGpsExifRemover'
 import { videoGpsMetadataRemoverSkip } from './videoGpsMetadataRemover'
-import type { ReadFunction, WriteFunction } from './gpsRemoverHelpers'
+import type { ReadFunction, WriteFunction, Options } from './gpsRemoverHelpers'
 import base64 from 'Base64'
 
 const isVideo = uri => /(mp4|m4v|webm|mov)/i.test(uri)
@@ -10,7 +10,9 @@ function removeFileSlashPrefix(path: string): string {
   return path.replace(/^(file:\/\/)/, '')
 }
 
-export const removeLocation = async (photoUri: string, read: ReadFunction, write: WriteFunction, skipXMPRemoval: boolean = false): Promise<boolean> => {
+export const removeLocation = async (photoUri: string, read: ReadFunction, write: WriteFunction, options: Options = {}): Promise<boolean> => {
+  const optionsWithDefaults = {skipXMPRemoval: false, ...options}
+  const { skipXMPRemoval } = optionsWithDefaults
   const preparedUri = removeFileSlashPrefix(photoUri)
   return isVideo(preparedUri)
     ? await videoGpsMetadataRemoverSkip(read, write, skipXMPRemoval)

--- a/src/videoGpsMetadataRemover.js
+++ b/src/videoGpsMetadataRemover.js
@@ -34,7 +34,7 @@ const wipeData = async (
 }
 
 export const videoGpsMetadataRemoverSkip
-= async (read: ReadFunction, write: WriteFunction): Promise<boolean> => {
+= async (read: ReadFunction, write: WriteFunction, skipXMPRemoval: boolean): Promise<boolean> => {
   console.log('preparing to read video skip...')
   let gpsTagFound = false
   let stopSearching = false
@@ -108,7 +108,7 @@ export const videoGpsMetadataRemoverSkip
       } else if (TAGS_TO_ENTER.includes(tagName)) {
         console.log('moov or udta tag found')
         offset += 8
-      } else if (tagName === UUID_TAG || tagName === XMP_TAG) {
+      } else if ((tagName === UUID_TAG || tagName === XMP_TAG) && !skipXMPRemoval) {
         // XMP is an alternative tag format pushed by adobe that can have gps
         // (can also be id'd by UUID atom)
         // we just want to wipe it


### PR DESCRIPTION
See this comment and the new readme update: https://github.com/xoeye/gps-metadata-remover/pull/6#pullrequestreview-682455608

Makes XMP removal optional for our users who need to leave XMP intact in their files.